### PR TITLE
FEAT: 유저의 댓글 삭제 기능 구현

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,68 +1,82 @@
 {
-  "currentUser": {
-    "image": { 
-      "png": "./images/avatars/image-juliusomo.png",
-      "webp": "./images/avatars/image-juliusomo.webp"
-    },
-    "username": "juliusomo"
-  },
-  "comments": [
-    {
-      "id": 1,
-      "content": "Impressive! Though it seems the drag feature could be improved. But overall it looks incredible. You've nailed the design and the responsiveness at various breakpoints works really well.",
-      "createdAt": "1 month ago",
-      "score": 12,
-      "user": {
-        "image": { 
-          "png": "./images/avatars/image-amyrobson.png",
-          "webp": "./images/avatars/image-amyrobson.webp"
-        },
-        "username": "amyrobson"
-      },
-      "replies": []
-    },
-    {
-      "id": 2,
-      "content": "Woah, your project looks awesome! How long have you been coding for? I'm still new, but think I want to dive into React as well soon. Perhaps you can give me an insight on where I can learn React? Thanks!",
-      "createdAt": "2 weeks ago",
-      "score": 5,
-      "user": {
-        "image": { 
-          "png": "./images/avatars/image-maxblagun.png",
-          "webp": "./images/avatars/image-maxblagun.webp"
-        },
-        "username": "maxblagun"
-      },
-      "replies": [
-        {
-          "id": 3,
-          "content": "If you're still new, I'd recommend focusing on the fundamentals of HTML, CSS, and JS before considering React. It's very tempting to jump ahead but lay a solid foundation first.",
-          "createdAt": "1 week ago",
-          "score": 4,
-          "replyingTo": "maxblagun",
-          "user": {
-            "image": { 
-              "png": "./images/avatars/image-ramsesmiron.png",
-              "webp": "./images/avatars/image-ramsesmiron.webp"
-            },
-            "username": "ramsesmiron"
-          }
-        },
-        {
-          "id": 4,
-          "content": "I couldn't agree more with this. Everything moves so fast and it always seems like everyone knows the newest library/framework. But the fundamentals are what stay constant.",
-          "createdAt": "2 days ago",
-          "score": 2,
-          "replyingTo": "ramsesmiron",
-          "user": {
-            "image": { 
-              "png": "./images/avatars/image-juliusomo.png",
-              "webp": "./images/avatars/image-juliusomo.webp"
-            },
-            "username": "juliusomo"
-          }
-        }
-      ]
-    }
-  ]
+	"currentUser": {
+		"image": {
+			"png": "./images/avatars/image-juliusomo.png",
+			"webp": "./images/avatars/image-juliusomo.webp"
+		},
+		"username": "juliusomo"
+	},
+	"comments": [
+		{
+			"id": 1,
+			"content": "Impressive! Though it seems the drag feature could be improved. But overall it looks incredible. You've nailed the design and the responsiveness at various breakpoints works really well.",
+			"createdAt": "1 month ago",
+			"score": 12,
+			"user": {
+				"image": {
+					"png": "./images/avatars/image-amyrobson.png",
+					"webp": "./images/avatars/image-amyrobson.webp"
+				},
+				"username": "amyrobson"
+			},
+			"replies": []
+		},
+		{
+			"id": 2,
+			"content": "Woah, your project looks awesome! How long have you been coding for? I'm still new, but think I want to dive into React as well soon. Perhaps you can give me an insight on where I can learn React? Thanks!",
+			"createdAt": "2 weeks ago",
+			"score": 5,
+			"user": {
+				"image": {
+					"png": "./images/avatars/image-maxblagun.png",
+					"webp": "./images/avatars/image-maxblagun.webp"
+				},
+				"username": "maxblagun"
+			},
+			"replies": [
+				{
+					"id": 3,
+					"content": "If you're still new, I'd recommend focusing on the fundamentals of HTML, CSS, and JS before considering React. It's very tempting to jump ahead but lay a solid foundation first.",
+					"createdAt": "1 week ago",
+					"score": 4,
+					"replyingTo": "maxblagun",
+					"user": {
+						"image": {
+							"png": "./images/avatars/image-ramsesmiron.png",
+							"webp": "./images/avatars/image-ramsesmiron.webp"
+						},
+						"username": "ramsesmiron"
+					}
+				},
+				{
+					"id": 4,
+					"content": "I couldn't agree more with this. Everything moves so fast and it always seems like everyone knows the newest library/framework. But the fundamentals are what stay constant.",
+					"createdAt": "2 days ago",
+					"score": 2,
+					"replyingTo": "ramsesmiron",
+					"user": {
+						"image": {
+							"png": "./images/avatars/image-juliusomo.png",
+							"webp": "./images/avatars/image-juliusomo.webp"
+						},
+						"username": "juliusomo"
+					}
+				}
+			]
+		},
+		{
+			"id": 5,
+			"content": "Impressive! Though it seems the drag feature could be improved. But overall it looks incredible. You've nailed the design and the responsiveness at various breakpoints works really well.",
+			"createdAt": "1 month ago",
+			"score": 12,
+			"user": {
+				"image": {
+					"png": "./images/avatars/image-juliusomo.png",
+					"webp": "./images/avatars/image-juliusomo.webp"
+				},
+				"username": "juliusomo"
+			},
+			"replies": []
+		}
+	]
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -27,7 +27,7 @@ export default class App extends Component {
 		const $commentsWrapper = document.querySelector('.comments-wrapper');
 		const $commentsFormWrapper = document.querySelector('.comments-form-wrapper');
 
-		new Comments($commentsWrapper, { comments: this.state.comments });
+		new Comments($commentsWrapper, { comments: this.state.comments, username: this.state.currentUser.username });
 		new CommentForm($commentsFormWrapper, {
 			currentUser: this.state.currentUser,
 			addComment: this.addComment.bind(this),

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -11,7 +11,7 @@ export default class App extends Component {
 		this.state = {
 			currentUser: data.currentUser,
 			comments: data.comments,
-			id: 5,
+			id: 6,
 		};
 	}
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -28,14 +28,16 @@ export default class App extends Component {
 	mounted() {
 		const $commentsWrapper = document.querySelector('.comments-wrapper');
 		const $commentsFormWrapper = document.querySelector('.comments-form-wrapper');
-		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
 
-		new Comments($commentsWrapper, { comments: this.state.comments, username: this.state.currentUser.username });
+		new Comments($commentsWrapper, {
+			comments: this.state.comments,
+			username: this.state.currentUser.username,
+			showModal: this.showModal.bind(this),
+		});
 		new CommentForm($commentsFormWrapper, {
 			currentUser: this.state.currentUser,
 			addComment: this.addComment.bind(this),
 		});
-		new DeleteModal($deleteModalWrapper);
 	}
 
 	addComment(newComment) {
@@ -52,5 +54,10 @@ export default class App extends Component {
 				},
 			],
 		});
+	}
+
+	showModal() {
+		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
+		new DeleteModal($deleteModalWrapper);
 	}
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -4,6 +4,7 @@ import { html } from '../../helper';
 import data from '../../../data.json';
 import CommentForm from '../CommentForm/CommentForm';
 import './App.css';
+import DeleteModal from '../DeleteModal/DeleteModal';
 
 export default class App extends Component {
 	setup() {
@@ -19,6 +20,7 @@ export default class App extends Component {
 			<div class="app">
 				<div class="comments-wrapper"></div>
 				<div class="comments-form-wrapper"></div>
+				<div class="delete-modal-wrapper"></div>
 			</div>
 		`;
 	}
@@ -26,12 +28,14 @@ export default class App extends Component {
 	mounted() {
 		const $commentsWrapper = document.querySelector('.comments-wrapper');
 		const $commentsFormWrapper = document.querySelector('.comments-form-wrapper');
+		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
 
 		new Comments($commentsWrapper, { comments: this.state.comments, username: this.state.currentUser.username });
 		new CommentForm($commentsFormWrapper, {
 			currentUser: this.state.currentUser,
 			addComment: this.addComment.bind(this),
 		});
+		new DeleteModal($deleteModalWrapper);
 	}
 
 	addComment(newComment) {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -58,6 +58,11 @@ export default class App extends Component {
 
 	showModal() {
 		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
-		new DeleteModal($deleteModalWrapper);
+		new DeleteModal($deleteModalWrapper, { closeModal: this.closeModal.bind(this) });
+	}
+
+	closeModal() {
+		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
+		$deleteModalWrapper.innerHTML = '';
 	}
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -56,13 +56,23 @@ export default class App extends Component {
 		});
 	}
 
-	showModal() {
+	showModal(id) {
 		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
-		new DeleteModal($deleteModalWrapper, { closeModal: this.closeModal.bind(this) });
+		new DeleteModal($deleteModalWrapper, {
+			closeModal: this.closeModal.bind(this),
+			deleteComment: this.deleteComment.bind(this),
+			commentId: id,
+		});
 	}
 
 	closeModal() {
 		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
 		$deleteModalWrapper.innerHTML = '';
+	}
+
+	deleteComment(id) {
+		const filteredComments = this.state.comments.filter((comment) => comment.id !== id);
+		this.setState({ comments: filteredComments });
+		this.closeModal();
 	}
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -38,6 +38,7 @@ export default class App extends Component {
 			currentUser: this.state.currentUser,
 			addComment: this.addComment.bind(this),
 		});
+		this.showModal();
 	}
 
 	addComment(newComment) {
@@ -63,11 +64,16 @@ export default class App extends Component {
 			deleteComment: this.deleteComment.bind(this),
 			commentId: id,
 		});
+
+		this.bodyOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
 	}
 
 	closeModal() {
 		const $deleteModalWrapper = document.querySelector('.delete-modal-wrapper');
 		$deleteModalWrapper.innerHTML = '';
+
+		document.body.style.overflow = this.bodyOverflow;
 	}
 
 	deleteComment(id) {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -38,7 +38,6 @@ export default class App extends Component {
 			currentUser: this.state.currentUser,
 			addComment: this.addComment.bind(this),
 		});
-		this.showModal();
 	}
 
 	addComment(newComment) {

--- a/src/components/Comment/Comment.css
+++ b/src/components/Comment/Comment.css
@@ -55,6 +55,14 @@
 	color: var(--dark-blue);
 }
 
+.current-user-badge {
+	padding: 3px 5px;
+	font-size: x-small;
+	border-radius: 3px;
+	background-color: var(--moderate-blue);
+	color: var(--white);
+}
+
 .elapsed-time {
 	font-weight: 200;
 	color: var(--grayish-blue);

--- a/src/components/Comment/Comment.css
+++ b/src/components/Comment/Comment.css
@@ -73,10 +73,23 @@
 	height: 25px;
 }
 
-.reply {
+.comment-button-container {
+	display: flex;
+	gap: 15px;
+}
+
+.comment-button {
 	display: flex;
 	align-items: center;
 	gap: 5px;
+}
+
+.delete {
+	color: var(--soft-red);
+}
+
+.reply,
+.edit {
 	color: var(--moderate-blue);
 }
 

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -47,19 +47,50 @@ export default class Comment extends Component {
 							${isCurrentUser ? `<div class="current-user-badge">you</div>` : ''}
 							<p class="elapsed-time">${comment.createdAt}</p>
 						</div>
-						<button class="reply">
-							<svg
-								width="14"
-								height="13"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<path
-									d="M.227 4.316 5.04.16a.657.657 0 0 1 1.085.497v2.189c4.392.05 7.875.93 7.875 5.093 0 1.68-1.082 3.344-2.279 4.214-.373.272-.905-.07-.767-.51 1.24-3.964-.588-5.017-4.829-5.078v2.404c0 .566-.664.86-1.085.496L.227 5.31a.657.657 0 0 1 0-.993Z"
-									fill="#5357B6"
-								/>
-							</svg>
-							Reply
-						</button>
+						${isCurrentUser
+							? `
+								<div class="comment-button-container">
+									<button class="delete comment-button">
+										<svg
+											width="12"
+											height="14"
+											xmlns="http://www.w3.org/2000/svg"
+										>
+											<path
+												d="M1.167 12.448c0 .854.7 1.552 1.555 1.552h6.222c.856 0 1.556-.698 1.556-1.552V3.5H1.167v8.948Zm10.5-11.281H8.75L7.773 0h-3.88l-.976 1.167H0v1.166h11.667V1.167Z"
+												fill="#ED6368"
+											/>
+										</svg>
+										<span>Delete</span>
+									</button>
+									<button class="edit comment-button">
+										<svg
+											width="14"
+											height="14"
+											xmlns="http://www.w3.org/2000/svg"
+										>
+											<path
+												d="M13.479 2.872 11.08.474a1.75 1.75 0 0 0-2.327-.06L.879 8.287a1.75 1.75 0 0 0-.5 1.06l-.375 3.648a.875.875 0 0 0 .875.954h.078l3.65-.333c.399-.04.773-.216 1.058-.499l7.875-7.875a1.68 1.68 0 0 0-.061-2.371Zm-2.975 2.923L8.159 3.449 9.865 1.7l2.389 2.39-1.75 1.706Z"
+												fill="#5357B6"
+											/>
+										</svg>
+										<span>Edit</span>
+									</button>
+								</div>
+							`
+							: `<button class="reply comment-button">
+						<svg
+							width="14"
+							height="13"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								d="M.227 4.316 5.04.16a.657.657 0 0 1 1.085.497v2.189c4.392.05 7.875.93 7.875 5.093 0 1.68-1.082 3.344-2.279 4.214-.373.272-.905-.07-.767-.51 1.24-3.964-.588-5.017-4.829-5.078v2.404c0 .566-.664.86-1.085.496L.227 5.31a.657.657 0 0 1 0-.993Z"
+								fill="#5357B6"
+							/>
+						</svg>
+						Reply
+					</button>`}
 					</section>
 					<p class="comment--content">${comment.content}</p>
 				</section>

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -97,4 +97,10 @@ export default class Comment extends Component {
 			</article>
 		`;
 	}
+
+	setEvent() {
+		this.addEvent('click', '.delete', () => {
+			this.props.showModal();
+		});
+	}
 }

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -100,7 +100,7 @@ export default class Comment extends Component {
 
 	setEvent() {
 		this.addEvent('click', '.delete', () => {
-			this.props.showModal();
+			this.props.showModal(this.props.comment.id);
 		});
 	}
 }

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -44,6 +44,7 @@ export default class Comment extends Component {
 								alt="user avatar"
 							/>
 							<p class="user-name">${comment.user.username}</p>
+							${isCurrentUser ? `<div class="current-user-badge">you</div>` : ''}
 							<p class="elapsed-time">${comment.createdAt}</p>
 						</div>
 						<button class="reply">

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -4,6 +4,8 @@ import './Comment.css';
 
 export default class Comment extends Component {
 	template() {
+		const { comment, isCurrentUser } = this.props;
+
 		return html`
 			<article class="comment">
 				<section class="like--container">
@@ -19,7 +21,7 @@ export default class Comment extends Component {
 							/>
 						</svg>
 					</button>
-					<p class="like--count">${this.props.score}</p>
+					<p class="like--count">${comment.score}</p>
 					<button class="like--minus like--button">
 						<svg
 							width="11"
@@ -38,11 +40,11 @@ export default class Comment extends Component {
 						<div class="meta-data-left">
 							<img
 								class="user-avatar"
-								src=${this.props.user.image.png}
+								src=${comment.user.image.png}
 								alt="user avatar"
 							/>
-							<p class="user-name">${this.props.user.username}</p>
-							<p class="elapsed-time">${this.props.createdAt}</p>
+							<p class="user-name">${comment.user.username}</p>
+							<p class="elapsed-time">${comment.createdAt}</p>
 						</div>
 						<button class="reply">
 							<svg
@@ -58,7 +60,7 @@ export default class Comment extends Component {
 							Reply
 						</button>
 					</section>
-					<p class="comment--content">${this.props.content}</p>
+					<p class="comment--content">${comment.content}</p>
 				</section>
 			</article>
 		`;

--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -13,7 +13,11 @@ export default class Comments extends Component {
 		const $comments = this.props.comments.map((comment) => {
 			const $li = document.createElement('li');
 
-			new Comment($li, { comment, isCurrentUser: comment.user.username === this.props.username });
+			new Comment($li, {
+				comment,
+				isCurrentUser: comment.user.username === this.props.username,
+				showModal: this.props.showModal,
+			});
 
 			return $li;
 		});

--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -13,7 +13,7 @@ export default class Comments extends Component {
 		const $comments = this.props.comments.map((comment) => {
 			const $li = document.createElement('li');
 
-			new Comment($li, comment);
+			new Comment($li, { comment, isCurrentUser: comment.user.username === this.props.username });
 
 			return $li;
 		});

--- a/src/components/DeleteModal/DeleteModal.css
+++ b/src/components/DeleteModal/DeleteModal.css
@@ -1,0 +1,52 @@
+.delete-modal--container {
+	position: fixed;
+	inset: 0;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 999;
+	background-color: hsl(var(--modal-background), 0.5);
+}
+
+.delete-modal {
+	padding: 30px;
+	display: flex;
+	flex-direction: column;
+	border-radius: 10px;
+	gap: 15px;
+	background-color: var(--white);
+}
+
+.delete-modal--title {
+	font-size: x-large;
+}
+
+.delete-modal--text {
+	font-weight: 200;
+	color: var(--grayish-blue);
+	max-width: 30ch;
+	line-height: 1.5rem;
+}
+
+.delete-modal-button--wrapper {
+	display: flex;
+	justify-content: space-between;
+}
+
+.delete-modal-button {
+	border-radius: 10px;
+	padding: 10px 20px;
+	color: var(--white);
+
+	&:hover {
+		opacity: 0.6;
+	}
+
+	&.no {
+		background-color: var(--grayish-blue);
+	}
+
+	&.yes {
+		background-color: var(--soft-red);
+	}
+}

--- a/src/components/DeleteModal/DeleteModal.js
+++ b/src/components/DeleteModal/DeleteModal.js
@@ -28,5 +28,12 @@ export default class DeleteModal extends Component {
 		this.addEvent('click', '.yes', () => {
 			this.props.deleteComment(this.props.commentId);
 		});
+
+		this.addEvent('click', '.delete-modal--container', (event) => {
+			const $deleteModal = this.$target.querySelector('.delete-modal');
+
+			if ($deleteModal?.contains(event.target)) return;
+			this.props.closeModal();
+		});
 	}
 }

--- a/src/components/DeleteModal/DeleteModal.js
+++ b/src/components/DeleteModal/DeleteModal.js
@@ -1,0 +1,20 @@
+import { html } from '../../helper';
+import Component from '../../core/Component';
+
+export default class DeleteModal extends Component {
+	template() {
+		return html`
+			<div class="delete-modal--container">
+				<div class="delete-modal">
+					<h1 class="delete-modal--title">Delete comment</h1>
+					<p class="delete-modal-text">
+						Are you sure you want to delete this comment? This will remove the comment and can't be undone.
+					</p>
+					<div class="delete-modal-button-wrapper">
+						<button class="no">NO, CANCEL</button><button class="yes">YES, DELETE</button>
+					</div>
+				</div>
+			</div>
+		`;
+	}
+}

--- a/src/components/DeleteModal/DeleteModal.js
+++ b/src/components/DeleteModal/DeleteModal.js
@@ -1,5 +1,6 @@
 import { html } from '../../helper';
 import Component from '../../core/Component';
+import './DeleteModal.css';
 
 export default class DeleteModal extends Component {
 	template() {
@@ -7,11 +8,12 @@ export default class DeleteModal extends Component {
 			<div class="delete-modal--container">
 				<div class="delete-modal">
 					<h1 class="delete-modal--title">Delete comment</h1>
-					<p class="delete-modal-text">
+					<p class="delete-modal--text">
 						Are you sure you want to delete this comment? This will remove the comment and can't be undone.
 					</p>
-					<div class="delete-modal-button-wrapper">
-						<button class="no">NO, CANCEL</button><button class="yes">YES, DELETE</button>
+					<div class="delete-modal-button--wrapper">
+						<button class="delete-modal-button no">NO, CANCEL</button>
+						<button class="delete-modal-button yes">YES, DELETE</button>
 					</div>
 				</div>
 			</div>

--- a/src/components/DeleteModal/DeleteModal.js
+++ b/src/components/DeleteModal/DeleteModal.js
@@ -22,5 +22,9 @@ export default class DeleteModal extends Component {
 		this.addEvent('click', '.no', () => {
 			this.props.closeModal();
 		});
+
+		this.addEvent('click', '.yes', () => {
+			this.props.deleteComment(this.props.commentId);
+		});
 	}
 }

--- a/src/components/DeleteModal/DeleteModal.js
+++ b/src/components/DeleteModal/DeleteModal.js
@@ -17,4 +17,10 @@ export default class DeleteModal extends Component {
 			</div>
 		`;
 	}
+
+	setEvent() {
+		this.addEvent('click', '.no', () => {
+			this.props.closeModal();
+		});
+	}
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -14,4 +14,5 @@
 	--light-gray: hsl(223, 19%, 93%);
 	--very-light-gray: hsl(228, 33%, 97%);
 	--white: hsl(0, 0%, 100%);
+	--modal-background: 0, 100%, 0%;
 }


### PR DESCRIPTION
## What?
유저가 댓글을 삭제할 수 있는 기능을 구현했습니다.

## Why?
해당 기능을 통해서 유저는 본인이 작성한 댓글을 삭제할 수 있습니다.

## How?
### 현재 유저 확인
- 특정 코멘트의 작성자가 현재 사용자와 동일인물인지 확인하는 변수를 만들어, 하위 컴포넌트에 props로 전달했습니다.
- Comment 컴포넌트에서 코멘트의 작성자와 현재 사용자가 동일인물이라면 아래와 같은 변화가 발생합니다.
  - Reply 버튼 대신에 Delete와 Edit 버튼이 보이도록 화면을 구성했습니다.
  - username 옆에 "you" 배지가 추가됩니다.

### 삭제
- Delete 버튼을 클릭하면 모달창이 열립니다.
- 모달창 안에 있는 "YES, DELETE" 버튼을 클릭하면 코멘트가 지워집니다.
- 모달창 안에 있는 "NO, CANCEL" 버튼을 클릭하면 모달창이 닫깁니다.
- 모달창 바깥의 배경을 클릭하면 모달창이 닫깁니다.
- 모달창이 열리면, 배경의 스크롤을 방지했습니다.

## Screenshots (optional)
![image](https://github.com/elice-study-first/interactive-comments-seungha/assets/67040204/b1a282f5-4eac-4155-b3a8-198f5f1947f7)
![image](https://github.com/elice-study-first/interactive-comments-seungha/assets/67040204/97ae5caf-7cd1-42c6-a800-e950c69100f2)


## Anything Else?
해당 pr과 관련된 이슈:
- #5 
- #12 
- #13